### PR TITLE
Use Blitz-Defined Ctx type

### DIFF
--- a/app/auth/components/LoginForm.tsx
+++ b/app/auth/components/LoginForm.tsx
@@ -1,8 +1,8 @@
 import React from "react"
-import { Link } from "blitz"
+import { Link, useMutation } from "blitz"
 import { LabeledTextField } from "app/components/LabeledTextField"
 import { Form, FORM_ERROR } from "app/components/Form"
-import login from "app/auth/mutations/login"
+import loginMutation from "app/auth/mutations/login"
 import { LoginInput, LoginInputType } from "app/auth/validations"
 
 type LoginFormProps = {
@@ -10,6 +10,7 @@ type LoginFormProps = {
 }
 
 export const LoginForm = (props: LoginFormProps) => {
+  const [login] = useMutation(loginMutation)
   return (
     <div>
       <h1>Login</h1>

--- a/app/auth/components/SignupForm.tsx
+++ b/app/auth/components/SignupForm.tsx
@@ -1,14 +1,16 @@
 import React from "react"
 import { LabeledTextField } from "app/components/LabeledTextField"
 import { Form, FORM_ERROR } from "app/components/Form"
-import signup from "app/auth/mutations/signup"
+import signupMutation from "app/auth/mutations/signup"
 import { SignupInput, SignupInputType } from "app/auth/validations"
+import { useMutation } from "blitz"
 
 type SignupFormProps = {
   onSuccess?: () => void
 }
 
 export const SignupForm = (props: SignupFormProps) => {
+  const [signup] = useMutation(signupMutation)
   return (
     <div>
       <h1>Create an Account</h1>

--- a/app/auth/mutations/login.ts
+++ b/app/auth/mutations/login.ts
@@ -1,8 +1,8 @@
-import { SessionContext } from "blitz"
 import { authenticateUser } from "app/auth/auth-utils"
 import { LoginInput, LoginInputType } from "../validations"
+import { Ctx } from "blitz"
 
-export default async function login(input: LoginInputType, ctx: { session?: SessionContext } = {}) {
+export default async function login(input: LoginInputType, ctx: Ctx) {
   // This throws an error if input is invalid
   const { email, password } = LoginInput.parse(input)
 

--- a/app/auth/mutations/logout.ts
+++ b/app/auth/mutations/logout.ts
@@ -1,5 +1,5 @@
-import { SessionContext } from "blitz"
+import { Ctx } from "blitz"
 
-export default async function logout(_ = null, ctx: { session?: SessionContext } = {}) {
+export default async function logout(_ = null, ctx: Ctx) {
   return await ctx.session!.revoke()
 }

--- a/app/auth/mutations/signup.ts
+++ b/app/auth/mutations/signup.ts
@@ -1,12 +1,9 @@
 import db from "db"
-import { SessionContext } from "blitz"
+import { Ctx } from "blitz"
 import { hashPassword } from "app/auth/auth-utils"
 import { SignupInput, SignupInputType } from "app/auth/validations"
 
-export default async function signup(
-  input: SignupInputType,
-  ctx: { session?: SessionContext } = {}
-) {
+export default async function signup(input: SignupInputType, ctx: Ctx) {
   // This throws an error if input is invalid
   const { email, password } = SignupInput.parse(input)
 

--- a/app/auth/types.ts
+++ b/app/auth/types.ts
@@ -1,0 +1,11 @@
+import { DefaultCtx, SessionContext, DefaultPublicData } from "blitz"
+import { User } from "db"
+
+declare module "blitz" {
+  export interface Ctx extends DefaultCtx {
+    session: SessionContext
+  }
+  export interface PublicData extends DefaultPublicData {
+    userId: User["id"]
+  }
+}

--- a/app/calendars/queries/getCalendars.ts
+++ b/app/calendars/queries/getCalendars.ts
@@ -1,7 +1,7 @@
 import db from "db"
-import { SessionContext } from "blitz"
+import { Ctx } from "blitz"
 
-export default async function getCalendars(_ = null, ctx: { session?: SessionContext } = {}) {
+export default async function getCalendars(_ = null, ctx: Ctx) {
   if (!ctx.session?.userId) return null
 
   const calendars = await db.connectedCalendar.findMany({

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -1,8 +1,7 @@
-import { Link, BlitzPage } from "blitz"
+import { Link, BlitzPage, useMutation } from "blitz"
 import Layout from "app/layouts/Layout"
-import logout from "app/auth/mutations/logout"
+import logoutMutation from "app/auth/mutations/logout"
 import { useCurrentUser } from "app/hooks/useCurrentUser"
-import { Suspense } from "react"
 
 /*
  * This file is just for a pleasant getting started page for your new app.
@@ -11,6 +10,7 @@ import { Suspense } from "react"
 
 const UserInfo = () => {
   const currentUser = useCurrentUser()
+  const [logout] = useMutation(logoutMutation)
 
   if (currentUser) {
     return (

--- a/app/users/queries/getCurrentUser.ts
+++ b/app/users/queries/getCurrentUser.ts
@@ -1,7 +1,7 @@
 import db from "db"
-import { SessionContext } from "blitz"
+import { Ctx } from "blitz"
 
-export default async function getCurrenAtUser(_ = null, ctx: { session?: SessionContext } = {}) {
+export default async function getCurrenAtUser(_ = null, ctx: Ctx) {
   if (!ctx.session?.userId) return null
 
   const user = await db.user.findOne({


### PR DESCRIPTION
This PR introduces the Blitz-defined `Ctx` type that replaces the wonky `ctx: { session?: SessionContext } = {}` parameter.