### PR TITLE
Fix test watch mode

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,7 @@ module.exports = {
     "\\.(gif|ttf|eot|svg|png|jpg|jpeg)$": "<rootDir>/test/__mocks__/fileMock.js",
   },
   watchPlugins: ["jest-watch-typeahead/filename", "jest-watch-typeahead/testname"],
+  watchPathIgnorePatterns: ["node_modules"],
   // Coverage output
   coverageDirectory: ".coverage",
   collectCoverageFrom: ["**/*.{js,jsx,ts,tsx}", "!**/*.d.ts", "!**/node_modules/**"],


### PR DESCRIPTION
Before, running `npm test -- --watch` failed with "too many files open". This PR fixes that.