### PR TITLE
Delete calendars

### DIFF
--- a/app/meetings/components/Meetings.tsx
+++ b/app/meetings/components/Meetings.tsx
@@ -1,8 +1,9 @@
 import { Card, Row, Col, Button } from "react-bootstrap"
 import type { Meeting } from "db"
-import { Link, useMutation } from "blitz"
+import { Link, useMutation, invalidateQuery } from "blitz"
 import { getOrigin } from "utils/generalUtils"
 import deleteMeetingMutation from "../mutations/deleteMeeting"
+import getMeetings from "../queries/getMeetings"
 
 interface MeetingsProps {
   meetings: Meeting[]
@@ -12,13 +13,8 @@ const Meetings = (props: MeetingsProps) => {
   const [deleteMeeting] = useMutation(deleteMeetingMutation)
 
   const submitDeletion = async (meetingId: number) => {
-    try {
-      const meeting = await deleteMeeting(meetingId)
-      const index = meetings.findIndex((meeting) => meeting.id === meetingId)
-      meetings.splice(index, 1)
-    } catch (error) {
-      alert(error)
-    }
+    const meeting = await deleteMeeting(meetingId)
+    invalidateQuery(getMeetings)
   }
 
   const { meetings } = props

--- a/app/users/components/ConnectedCalendars.tsx
+++ b/app/users/components/ConnectedCalendars.tsx
@@ -1,12 +1,25 @@
 import { ConnectedCalendar } from "@prisma/client"
-import { Link } from "blitz"
+import { useMutation } from "blitz"
 import { Button, Table } from "react-bootstrap"
+import deleteConnectedCalendar from "../mutations/deleteConnectedCalendar"
 
 interface ConnectedCalendarsProps {
   calendars: Omit<ConnectedCalendar, "encryptedPassword">[]
 }
 
 const ConnectedCalendars = (props: ConnectedCalendarsProps) => {
+  const [deleteCalendar] = useMutation(deleteConnectedCalendar)
+
+  const submitDeletion = async (calendarId: number) => {
+    try {
+      const calendar = await deleteCalendar(calendarId)
+      const index = props.calendars.findIndex((calendarEntry) => calendarEntry.id === calendarId)
+      props.calendars.splice(index, 1)
+    } catch (error) {
+      alert(error)
+    }
+  }
+
   return (
     <Table>
       <thead>
@@ -24,9 +37,9 @@ const ConnectedCalendars = (props: ConnectedCalendarsProps) => {
             <td className="align-middle">{calendarEntry.type}</td>
             <td className="align-middle">{calendarEntry.status}</td>
             <td>
-              <Link href="/tobeimplemented">
-                <Button variant="link">Edit</Button>
-              </Link>
+              <Button variant="link" onClick={() => submitDeletion(calendarEntry.id)}>
+                Delete
+              </Button>
             </td>
           </tr>
         ))}

--- a/app/users/components/ConnectedCalendars.tsx
+++ b/app/users/components/ConnectedCalendars.tsx
@@ -1,7 +1,8 @@
 import { ConnectedCalendar } from "@prisma/client"
-import { useMutation } from "blitz"
+import { useMutation, invalidateQuery } from "blitz"
 import { Button, Table } from "react-bootstrap"
 import deleteConnectedCalendar from "../mutations/deleteConnectedCalendar"
+import getConnectedCalendars from "../queries/getConnectedCalendars"
 
 interface ConnectedCalendarsProps {
   calendars: Omit<ConnectedCalendar, "encryptedPassword">[]
@@ -11,13 +12,8 @@ const ConnectedCalendars = (props: ConnectedCalendarsProps) => {
   const [deleteCalendar] = useMutation(deleteConnectedCalendar)
 
   const submitDeletion = async (calendarId: number) => {
-    try {
-      const calendar = await deleteCalendar(calendarId)
-      const index = props.calendars.findIndex((calendarEntry) => calendarEntry.id === calendarId)
-      props.calendars.splice(index, 1)
-    } catch (error) {
-      alert(error)
-    }
+    const calendar = await deleteCalendar(calendarId)
+    invalidateQuery(getConnectedCalendars)
   }
 
   return (

--- a/app/users/mutations/deleteConnectedCalendar.tsx
+++ b/app/users/mutations/deleteConnectedCalendar.tsx
@@ -1,0 +1,20 @@
+import db from "db"
+import { Ctx } from "blitz"
+
+export default async function deleteConnectedCalendar(calendarId: number, ctx: Ctx) {
+  ctx.session.authorize()
+
+  const owner = await db.user.findFirst({
+    where: { id: ctx.session.userId },
+  })
+
+  if (!owner) {
+    throw new Error("Invariant failed: Owner does not exist.")
+  }
+
+  const calendar = await db.connectedCalendar.delete({
+    where: { id: calendarId },
+  })
+
+  return calendar
+}

--- a/app/users/mutations/deleteConnectedCalendar.tsx
+++ b/app/users/mutations/deleteConnectedCalendar.tsx
@@ -4,17 +4,9 @@ import { Ctx } from "blitz"
 export default async function deleteConnectedCalendar(calendarId: number, ctx: Ctx) {
   ctx.session.authorize()
 
-  const owner = await db.user.findFirst({
-    where: { id: ctx.session.userId },
+  const count = await db.connectedCalendar.deleteMany({
+    where: { id: calendarId, ownerId: ctx.session.userId },
   })
 
-  if (!owner) {
-    throw new Error("Invariant failed: Owner does not exist.")
-  }
-
-  const calendar = await db.connectedCalendar.delete({
-    where: { id: calendarId },
-  })
-
-  return calendar
+  return count
 }

--- a/app/users/mutations/deleteConnectedCalendar.tsx
+++ b/app/users/mutations/deleteConnectedCalendar.tsx
@@ -4,9 +4,9 @@ import { Ctx } from "blitz"
 export default async function deleteConnectedCalendar(calendarId: number, ctx: Ctx) {
   ctx.session.authorize()
 
-  const count = await db.connectedCalendar.deleteMany({
+  const result = await db.connectedCalendar.deleteMany({
     where: { id: calendarId, ownerId: ctx.session.userId },
   })
 
-  return count === 1 ? "success" : "not_found"
+  return result.count === 1 ? "success" : "error"
 }

--- a/app/users/mutations/deleteConnectedCalendar.tsx
+++ b/app/users/mutations/deleteConnectedCalendar.tsx
@@ -8,5 +8,5 @@ export default async function deleteConnectedCalendar(calendarId: number, ctx: C
     where: { id: calendarId, ownerId: ctx.session.userId },
   })
 
-  return count
+  return count === 1 ? "success" : "not_found"
 }


### PR DESCRIPTION
Closes: #102 

Allows users to delete a connected calendar. 
Does NOT implement CASCADE deletion of meetings because they are currently not assigned to a specific calendar.

CASCADE deletion should be implemented in connection to #113.
