### PR TITLE
Put Baikal state into its own Dockerfile

### DIFF
--- a/app/caldav/index.server.test.ts
+++ b/app/caldav/index.server.test.ts
@@ -10,17 +10,6 @@ import * as path from "path"
 import { addMinutes } from "date-fns"
 import childProcess from "child_process"
 
-async function getBaikalContainer() {
-  return new GenericContainer("ckulka/baikal", "0.7.2-nginx")
-    .withExposedPorts(80)
-    .withBindMount(
-      path.join(__dirname, "../../test/baikal/Specific"),
-      "/var/www/baikal/Specific",
-      "rw"
-    )
-    .withBindMount(path.join(__dirname, "../../test/baikal/config"), "/var/www/baikal/config", "rw")
-}
-
 function exec(command: string, cwd = process.cwd()) {
   return new Promise<void>((resolve, reject) => {
     const $ = childProcess.exec(command, {
@@ -37,14 +26,19 @@ function exec(command: string, cwd = process.cwd()) {
   })
 }
 
-async function getNextcloudContainer() {
-  // for some reason, testcontainer's build doesn't want to work.
-  // that's why we build it by hand ...
-  await exec(
-    "docker buildx build -t nc-with-cal .",
-    path.resolve(__dirname, "../../test/nextcloud")
-  )
+// for some reason, testcontainer's build doesn't want to work.
+// that's why we build it by hand ...
+async function buildByHand(context: string, name: string) {
+  return await exec(`docker buildx build -t ${name} .`, path.resolve(__dirname, context))
+}
 
+async function getBaikalContainer() {
+  await buildByHand("../../test/baikal", "baikal-with-cal")
+  return new GenericContainer("baikal-with-cal").withExposedPorts(80)
+}
+
+async function getNextcloudContainer() {
+  await buildByHand("../../test/nextcloud", "nc-with-cal")
   return new GenericContainer("nc-with-cal").withExposedPorts(80)
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,9 @@ services:
       POSTGRES_DB: kalle
 
   baikal:
-    image: ckulka/baikal:0.7.2-nginx
+    build: test/baikal
     ports:
       - 5232:80
-    volumes:
-      - ./test/baikal/Specific:/var/www/baikal/Specific
-      - ./test/baikal/config:/var/www/baikal/config
 
   mailhog:
     image: mailhog/mailhog

--- a/test/baikal/Dockerfile
+++ b/test/baikal/Dockerfile
@@ -1,0 +1,7 @@
+FROM ckulka/baikal:0.7.2-nginx
+
+COPY ./config /var/www/baikal/config/
+COPY ./Specific /var/www/baikal/Specific/
+
+RUN chmod -R 777 /var/www/baikal/config/
+RUN chmod -R 777 /var/www/baikal/Specific/


### PR DESCRIPTION
Before every run of "npm test" changed the Baïkal DB and you had to manually revert it.
This PR moves all of the Baikal calendar state into the image itself, removing the need for mounted volumes and thus saving us from reverting all the time.