### PR TITLE
adds promp: 'consent'

### DIFF
--- a/app/calendar/googlecalendar/queries/createConnection.ts
+++ b/app/calendar/googlecalendar/queries/createConnection.ts
@@ -5,6 +5,7 @@ export default async function getCcalOAuthUrl(_ = null) {
 
   return createGoogleOauth().generateAuthUrl({
     access_type: "offline",
+    prompt: 'consent',
     scope: scopes,
   })
 }


### PR DESCRIPTION
When registering the same google account multiple times, google will not provide multiple refresh tokens. This fixes the problem (missing refreshTokens) because it forces google to return a calendar.