### PR TITLE
include last slot for last day of meeting

### DIFF
--- a/app/appointments/utils/scheduleToTakenSlots.spec.ts
+++ b/app/appointments/utils/scheduleToTakenSlots.spec.ts
@@ -46,6 +46,10 @@ describe("scheduleToTakenSlots", () => {
         start: new Date("2021-01-01T17:00:00.000+01:00"),
         end: new Date("2021-01-04T09:00:00.000+01:00"),
       },
+      {
+        start: new Date("2021-01-04T17:00:00.000+01:00"),
+        end: new Date("2021-01-05T09:00:00.000+01:00"),
+      },
     ])
   })
 
@@ -75,6 +79,10 @@ describe("scheduleToTakenSlots", () => {
       {
         start: new Date("2019-10-27T17:00:00.000+01:00"),
         end: new Date("2019-10-28T09:00:00.000+01:00"),
+      },
+      {
+        start: new Date("2019-10-28T17:00:00.000+01:00"),
+        end: new Date("2019-10-29T09:00:00.000+01:00"),
       },
     ])
   })

--- a/app/appointments/utils/scheduleToTakenSlots.ts
+++ b/app/appointments/utils/scheduleToTakenSlots.ts
@@ -46,18 +46,16 @@ export function scheduleToTakenSlots(
   }
 
   const result: TimeSlot[] = []
-
   let cursor = between.start
-  while (cursor <= between.end) {
+
+  //we need to include the blocked slot between the end of the last day (between.end) and beginning of the next day (addDays(between.end, 1))
+  while (cursor <= addDays(between.end, 1)) {
     const slot: TimeSlot = {
       start: endOfLastWorkDayBefore(cursor, schedule, timezone),
       end: startOfFirstWorkDayAfter(cursor, schedule, timezone),
     }
-
     result.push(slot)
-
     cursor = addDays(slot.end, 1)
   }
-
   return result
 }


### PR DESCRIPTION
Closes: #204 

**Why is it correct to change the tests?**
The test assumed that the last day does not need a blocked slot for its ending. Presumably because they were written with the assumption that the time included in the end Date of the meeting is considered in the implementation (meaning that if a meeting is until `2021-01-04T10:00:00.000Z`, all slots after 10 am are automatically cut off). However, this is not the case, because user specify the last possible day of a meeting, but not specifically it's time. Thus, the algorithm correctly checks the last taken slot for the end of the end day - and this should be reflected in the test as well.